### PR TITLE
Add app namespace to PHP scripts

### DIFF
--- a/.init.php
+++ b/.init.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\http\request;
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(false)

--- a/action.php
+++ b/action.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 const ACCESS = true;
 

--- a/api.file.php
+++ b/api.file.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\http\request;
 use ngatngay\fs;

--- a/checkhealth.php
+++ b/checkhealth.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 const ACCESS = true;
 

--- a/create.php
+++ b/create.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 const ACCESS = true;
 

--- a/db/adminneo-config.php
+++ b/db/adminneo-config.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 return [
     'hiddenDatabases' => '__system',

--- a/db/index.php
+++ b/db/index.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 isset($_COOKIE["fm_php"]) or exit;
 

--- a/delete_line.php
+++ b/delete_line.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 const ACCESS = true;
 

--- a/edit_api.php
+++ b/edit_api.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\http\request;
 

--- a/edit_code.php
+++ b/edit_code.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/edit_line.php
+++ b/edit_line.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/edit_text.php
+++ b/edit_text.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\http\request;
 

--- a/edit_text_line.php
+++ b/edit_text_line.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/file.php
+++ b/file.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\http\request;
 

--- a/file_move.php
+++ b/file_move.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/file_unzip.php
+++ b/file_unzip.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\fs;
 use ngatngay\http\request;

--- a/file_viewzip.php
+++ b/file_viewzip.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/find_in_folder.php
+++ b/find_in_folder.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/fix_permission.php
+++ b/fix_permission.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\http\request;
 

--- a/folder_compare_simple.php
+++ b/folder_compare_simple.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/folder_copy.php
+++ b/folder_copy.php
@@ -1,4 +1,7 @@
-<?php define('ACCESS', true);
+<?php
+namespace app;
+
+define('ACCESS', true);
 
     include_once '.init.php';
 

--- a/folder_move.php
+++ b/folder_move.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/folder_zip.php
+++ b/folder_zip.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/footer.php
+++ b/footer.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 defined('ACCESS') or exit('Not access');
 

--- a/header.php
+++ b/header.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 defined('ACCESS') or exit('Not access');
 

--- a/import.php
+++ b/import.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\http\curl;
 

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\fs;
 

--- a/lib/auth.fn.php
+++ b/lib/auth.fn.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 // auth
 function getLoginFail()

--- a/lib/bookmark.fn.php
+++ b/lib/bookmark.fn.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 function bookmark_get()
 {

--- a/lib/file.fn.php
+++ b/lib/file.fn.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 function zipDir($path, $file, $isDelete = false)
 {

--- a/lib/function.php
+++ b/lib/function.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use function ngatngay\response as response2;
 use function ngatngay\redirect;

--- a/lib/zip.class.php
+++ b/lib/zip.class.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 class Zip extends ZipArchive {
     public function add($path, $relative = null)

--- a/login.php
+++ b/login.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 const ACCESS = true;
 const LOGIN  = true;

--- a/logout.php
+++ b/logout.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/phpinfo.php
+++ b/phpinfo.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 if (isset($_COOKIE['fm_php'])) {
     phpinfo();

--- a/read_image.php
+++ b/read_image.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 const ACCESS = true;
 

--- a/rector.php
+++ b/rector.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\SetList;

--- a/reinstall.php
+++ b/reinstall.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/run_command.php
+++ b/run_command.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/run_composer.php
+++ b/run_composer.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/scan_error_log.php
+++ b/scan_error_log.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use ngatngay\fs;
 

--- a/setting.php
+++ b/setting.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 const ACCESS = true;
 define('alwaysCheckUpdate', true);

--- a/setting_home.php
+++ b/setting_home.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/update.class.php
+++ b/update.class.php
@@ -1,5 +1,7 @@
 <?php
-  class Update {         
+namespace app;
+
+class Update {         
     public function __construct() {    
          
     }

--- a/update.php
+++ b/update.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 exit('cho nguoi bao tri');
 

--- a/upload.php
+++ b/upload.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use function ngatngay\response;
 

--- a/view_code.php
+++ b/view_code.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 define('ACCESS', true);
 

--- a/webdav.php
+++ b/webdav.php
@@ -1,4 +1,5 @@
 <?php
+namespace app;
 
 use Sabre\DAV\Auth\Backend\BasicCallBack;
 use Sabre\DAV\Server;


### PR DESCRIPTION
## Summary
- Declare `namespace app;` in all PHP scripts for consistent namespacing

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_6897f1fc4704832a8003ff144cb69d33