### PR TITLE
Replace const declarations with define

### DIFF
--- a/.init.php
+++ b/.init.php
@@ -77,32 +77,32 @@ define('icons', [
 ]);
 
 // cau hinh
-const PATH_CONFIG = rootPath . '/config.inc.php';
+define('PATH_CONFIG', rootPath . '/config.inc.php');
 
 define('pathConfig', rootPath . '/config.inc.php');
 define('pathDatabase', rootPath . '/config.db.inc.php');
 
-const LOGIN_USERNAME_DEFAULT = 'Admin';
-const LOGIN_PASSWORD_DEFAULT = '12345';
+define('LOGIN_USERNAME_DEFAULT', 'Admin');
+define('LOGIN_PASSWORD_DEFAULT', '12345');
 
-const LOGIN_LOCK = 'login_fail';
-const LOGIN_MAX = 5;
+define('LOGIN_LOCK', 'login_fail');
+define('LOGIN_MAX', 5);
 
-const PAGE_LIST_DEFAULT = 1000;
-const PAGE_FILE_EDIT_DEFAULT = 1000000;
-const PAGE_FILE_EDIT_LINE_DEFAULT = 100;
-const PAGE_DATABASE_LIST_ROWS_DEFAULT = 100;
+define('PAGE_LIST_DEFAULT', 1000);
+define('PAGE_FILE_EDIT_DEFAULT', 1000000);
+define('PAGE_FILE_EDIT_LINE_DEFAULT', 100);
+define('PAGE_DATABASE_LIST_ROWS_DEFAULT', 100);
 
-const PAGE_NUMBER      = 7;
-const PAGE_URL_DEFAULT = 'default';
-const PAGE_URL_START   = 'start';
-const PAGE_URL_END     = 'end';
+define('PAGE_NUMBER', 7);
+define('PAGE_URL_DEFAULT', 'default');
+define('PAGE_URL_START', 'start');
+define('PAGE_URL_END', 'end');
 
-const DEVELOPMENT          = false;
-const NAME_SUBSTR          = 1000;
-const NAME_SUBSTR_ELLIPSIS = '...';
+define('DEVELOPMENT', false);
+define('NAME_SUBSTR', 1000);
+define('NAME_SUBSTR_ELLIPSIS', '...');
 
-const FM_COOKIE_NAME = 'fm_php';
+define('FM_COOKIE_NAME', 'fm_php');
 
 { // lay thong tin phien ban hien tai
     $version = json_decode(

--- a/action.php
+++ b/action.php
@@ -1,7 +1,7 @@
 <?php
 namespace app;
 
-const ACCESS = true;
+define('ACCESS', true);
 
 require '.init.php';
 

--- a/checkhealth.php
+++ b/checkhealth.php
@@ -1,7 +1,7 @@
 <?php
 namespace app;
 
-const ACCESS = true;
+define('ACCESS', true);
 
 require '.init.php';
 

--- a/create.php
+++ b/create.php
@@ -1,7 +1,7 @@
 <?php
 namespace app;
 
-const ACCESS = true;
+define('ACCESS', true);
 
 require '.init.php';
 

--- a/db/admin
+++ b/db/admin
@@ -2139,11 +2139,7 @@ int32((($mm>>5&0x7FFFFFF)^$lm<<2)+(($lm>>3&0x1FFFFFFF)^$mm<<4))^int32(($ok^$lm)+
 xxtea_encrypt_string($ci,$w){$w=array_values(unpack("V*",pack("H*",md5($w))));$W=str2long($ci,true);$Hg=count($W)-1;$mm=$W[$Hg];$lm=$W[0];$yi=floor(6+52/($Hg+1));$ok=0;while($yi-->0){$ok=int32($ok+0x9E3779B9);$Yc=$ok>>2&3;for($Hh=0;$Hh<$Hg;$Hh++){$lm=$W[$Hh+1];$Fg=xxtea_mx($mm,$lm,$ok,$w[$Hh&3^$Yc]);$mm=int32($W[$Hh]+$Fg);$W[$Hh]=$mm;}$lm=$W[0];$Fg=xxtea_mx($mm,$lm,$ok,$w[$Hh&3^$Yc]);$mm=int32($W[$Hg]+$Fg);$W[$Hg]=$mm;}return
 long2str($W,false);}function
 xxtea_decrypt_string($g,$w){$w=array_values(unpack("V*",pack("H*",md5($w))));$W=str2long($g,false);$Hg=count($W)-1;$mm=$W[$Hg];$lm=$W[0];$yi=floor(6+52/($Hg+1));$ok=int32($yi*0x9E3779B9);while($ok){$Yc=$ok>>2&3;for($Hh=$Hg;$Hh>0;$Hh--){$mm=$W[$Hh-1];$Fg=xxtea_mx($mm,$lm,$ok,$w[$Hh&3^$Yc]);$lm=int32($W[$Hh]-$Fg);$W[$Hh]=$lm;}$mm=$W[$Hg];$Fg=xxtea_mx($mm,$lm,$ok,$w[$Hh&3^$Yc]);$lm=int32($W[0]-$Fg);$W[0]=$lm;$ok=int32($ok-0x9E3779B9);}return
-long2str($W,true);}const
-ENCRYPTION_GCM='aes-256-gcm';const
-ENCRYPTION_CBC='aes-256-cbc';const
-ENCRYPTION_TAG_LENGTH=16;const
-ENCRYPTION_HMAC_LENGTH=64;function
+long2str($W,true);}define('ENCRYPTION_GCM','aes-256-gcm');define('ENCRYPTION_CBC','aes-256-cbc');define('ENCRYPTION_TAG_LENGTH',16);define('ENCRYPTION_HMAC_LENGTH',64);function
 generate_iv($Rf){if(function_exists('random_bytes')){try{return
 random_bytes($Rf);}catch(Exception$Yc){}}return
 openssl_random_pseudo_bytes($Rf);}function

--- a/delete_line.php
+++ b/delete_line.php
@@ -1,7 +1,7 @@
 <?php
 namespace app;
 
-const ACCESS = true;
+define('ACCESS', true);
 
 require '.init.php';
 

--- a/import.php
+++ b/import.php
@@ -3,7 +3,7 @@ namespace app;
 
 use ngatngay\http\curl;
 
-const ACCESS = true;
+define('ACCESS', true);
 
 require '.init.php';
 

--- a/index.php
+++ b/index.php
@@ -3,8 +3,8 @@ namespace app;
 
 use ngatngay\fs;
 
-const ACCESS = true;
-const INDEX  = true;
+define('ACCESS', true);
+define('INDEX', true);
 
 require '.init.php';
 

--- a/login.php
+++ b/login.php
@@ -1,8 +1,8 @@
 <?php
 namespace app;
 
-const ACCESS = true;
-const LOGIN  = true;
+define('ACCESS', true);
+define('LOGIN', true);
 
 require '.init.php';
 

--- a/read_image.php
+++ b/read_image.php
@@ -1,7 +1,7 @@
 <?php
 namespace app;
 
-const ACCESS = true;
+define('ACCESS', true);
 
 include '.init.php';
 

--- a/setting.php
+++ b/setting.php
@@ -1,7 +1,7 @@
 <?php
 namespace app;
 
-const ACCESS = true;
+define('ACCESS', true);
 define('alwaysCheckUpdate', true);
 
 require '.init.php';

--- a/webdav.php
+++ b/webdav.php
@@ -7,8 +7,8 @@ use Sabre\DAV\FS\Directory;
 use Sabre\DAV\Auth\Plugin;
 use ngatngay\http\request;
 
-const ACCESS = true;
-const LOGIN  = true;
+define('ACCESS', true);
+define('LOGIN', true);
 
 require '.init.php';
 


### PR DESCRIPTION
## Summary
- Replace PHP `const` declarations with `define()` across the application.

## Testing
- `php -l index.php checkhealth.php action.php import.php delete_line.php login.php setting.php read_image.php create.php webdav.php .init.php db/admin`


------
https://chatgpt.com/codex/tasks/task_e_6897f5347c44832ab4da35935f0f9b06